### PR TITLE
settings.json: update mainnet chief address

### DIFF
--- a/src/settings.json
+++ b/src/settings.json
@@ -7,7 +7,7 @@
         "chief": "0xbbffc76e94b34f72d96d054b31f6424249c1337d"
       },
       "main": {
-        "chief": "0x8e2a84d6ade1e7fffee039a35ef5f19f13057152"
+        "chief": "0x9eF05f7F6deB616fd37aC3c959a2dDD25A54E4F5"
       }
     }
   }


### PR DESCRIPTION
address previously was the buggy chief that was replaced on 06/05/2019

https://www.reddit.com/r/MakerDAO/comments/ble9j1/notice_critical_update_to_governance_voting/
https://blog.openzeppelin.com/technical-description-of-makerdao-governance-critical-vulnerability-facce6bf5d5e/